### PR TITLE
Allow Pirates to overkill

### DIFF
--- a/batsim.js
+++ b/batsim.js
@@ -4496,7 +4496,7 @@ function doTurn (A,D,turnA,turnD,side) {
         var finalDamage = Math.round(dmgAfterDefense);
         var forcesuper=false;
         if (i==0 && (D.setup[i].hp - finalDamage) / D.setup[i].mhp <= atk.killIfUnder && atk.killIfUnder!==0) {
-            finalDamage=(D.setup[i].hp+1);
+            finalDamage=Math.max(finalDamage,D.setup[i].hp+1);
             forcesuper=true;
         }
         if (atk.damage>0&&atk.damageFactor[i]>0) {


### PR DESCRIPTION
Overkilling a creature is important aspect of the game, either for tiebreaker, reflecting damage, or killing a Neil, so allow pirates to overkilling. Otherwise it may just do 1 damage instead of Pirates actual attack.