### PR TITLE
Fix (a)Defile's skill triggered too often

### DIFF
--- a/batsim.js
+++ b/batsim.js
@@ -4578,7 +4578,7 @@ function doTurn (A,D,turnA,turnD,side) {
         
         // new turns
         if (D.setup[i].hp<=0 && initHp>0) {
-            if (turnA.onkill.moob!==0) {
+            if (turnA.onkill.moob!==0&&i==0) {
                 if (retturn.self===undefined) retturn.self=getTurnData(A.setup.length,D.setup.length);
                 for (var j=0; j<retturn.self.atk.flatAoe.length; ++j) {
                     retturn.self.atk.flatAoe[j]+=turnA.onkill.moob;


### PR DESCRIPTION
(a)Defile's skill is often triggered by a non-front unit dies from AOE from another unit than defile. So Defile did not kill it but triggers anyhow, which does not match the description.