### PR TITLE
Neil and turn damage is surprisingly wrong

### DIFF
--- a/batsim.js
+++ b/batsim.js
@@ -4779,6 +4779,7 @@ function doTurn (A,D,turnA,turnD,side) {
             for (var j=i+1; j<D.setup.length; ++j) {
                 var tankDamage = Math.round(dmgAfterDefense*buff.tank[j]);
                 if (tankDamage) {
+	            turndmg+=tankDamage;
                     D.setup[j].hp -= tankDamage;
                     gBattle.steps.push({
                         action:"HIT",
@@ -4792,7 +4793,6 @@ function doTurn (A,D,turnA,turnD,side) {
                 }
             }
             dmgAfterDefense*=buff.tank[i];
-            turndmg+=tankDamage;
         }
         var finalDamage = Math.round(dmgAfterDefense);
         var forcesuper=false;


### PR DESCRIPTION
The code updates turndmg for a tank after evaluating all potential units in sequence, which means tankDamage for the last unit is used. So if Neil is NOT last, then tankDamage is 0, and opponent is not given enough turn dmg (potential 1000+ dmg).  It is surprising that it has not been discovered before, but apparently some js engines, will not assign tankDamage if it is not used in the codeblock it is declared. The only case where it IS used is when it is not 0, and given there only is 1 tank in a line, it keeps the value until it is used for turndmg, so this hides the bug. My ff does this. I am very certain whatever js engine is used for eval tournaments does not, as it matches nearly cases where servers replay strings winner does not match what is seen in my client in FF.