### PR TITLE
Bubbles inhibits Spykes attack increase

### DIFF
--- a/batsim.js
+++ b/batsim.js
@@ -4828,7 +4828,7 @@ function doTurn (A,D,turnA,turnD,side) {
         }
         // Buffs
         var tmpatk = D.setup[i].atk;
-        D.setup[i].atk+=buff.iAtk[i]*buff.ratio;
+        D.setup[i].atk+=buff.iAtk[i];
         D.setup[i].atk*=buff.iAtkPerc[i];
         D.setup[i].atk=Math.round(D.setup[i].atk);
         if (D.setup[i].atk!=tmpatk) {


### PR DESCRIPTION
In a team with Bubbles + Spyke, spykes +10 each round is decreased by bubbles skill. This is most definitly not wanted, and strange.
It could be changed to use any enemys bubbles skill, however if it was Bubbles + Putrid this would be bad aswell.
So pull request to remove bubbles skill effecting iAtk.