### PR TITLE
Sanqueen is assymetric

### DIFF
--- a/batsim.js
+++ b/batsim.js
@@ -5086,7 +5086,7 @@ function doTurn (A,D,turnA,turnD,side) {
         var initHp = D.setup[i].hp;
         D.setup[i].hp -= totalDamage;
         turndmg += totalDamage;
-        if (atk.leech>0 && totalDamage>0 && A.setup[0].hp>0) {
+        if (atk.leech>0 && totalDamage>0) {
             if (retturn.self===undefined) retturn.self=getTurnData(A.setup.length,D.setup.length);
             retturn.self.buff.heal[0]+=Math.round(finalDamage*atk.leech);
         }


### PR DESCRIPTION
Sanqueen's code checks that she is alive before applying leech. However the check is sort of wrong, as the two sides takes turn to fight. So the first to go will not see her as dead (yet) and apply heal. That heal will go to the next unit. However the second to go will see her as dead and not apply the heal to next unit. 

I dont see an easy solution with current code. 
1) Either remove the check, so she always heal next unit (strange, but fair).
2) Stop removing dead units in subturns.

Patch for 1)